### PR TITLE
'Not an ARRAY reference' in DBSet::add for at least v5.16.3

### DIFF
--- a/script/schwartzmon
+++ b/script/schwartzmon
@@ -249,7 +249,7 @@ package DBSet;
 sub new {
     my ( $this, $args ) = @_;
     my $class = ref($this) || $this;
-    return bless {}, $class;
+    return bless [], $class;
 }
 
 sub add {


### PR DESCRIPTION
Constructor makes a hashref but DBSet::push uses it as an array

This change makes the object data type an arrayref instead of hashref so that
::push works and schwartzmon can run again